### PR TITLE
- exception on non existent key retrieval fixed

### DIFF
--- a/src/main/java/storm/trident/redis/RedisState.java
+++ b/src/main/java/storm/trident/redis/RedisState.java
@@ -206,7 +206,7 @@ public class RedisState<T> implements IBackingMap<T> {
       for (List<Object> key : keys) {
          String strKey = keyFactory.build(key);
          byte[] bytes = keyValue.get(strKey.getBytes());
-         values.add(new String(bytes));
+         values.add(bytes == null ? null : new String(bytes));
       }
       return values;
    }


### PR DESCRIPTION
In multiGet operation, if there is no specified key in map, it throws exception. I have added simple check.
